### PR TITLE
Move authors to data

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,62 @@
+Ben Phillips:
+  name   : "Ben Phillips"
+  short_name: Ben
+  name_title: Prof.
+  avatar : "/assets/images/mugshots/ben.png"
+  position: "Premier's Science Fellow"
+  institution: Curtin University
+  email: ben.l.phillips@curtin.edu.au
+  home: "https://benflips.github.io/PBG/team/ben/"
+  bio    : "Professor of population biology at Curtin"
+  links:
+    - label: "Website"
+      icon: "fas fa-fw fa-link"
+      url: "https://benflips.github.io/PBG"
+    - label: "Twitter"
+      icon: "fab fa-fw fa-twitter-square"
+      url: "https://twitter.com/benflips"
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/benflips"
+    - label: "Keybase"
+      icon: "fab fa-keybase"
+      url: "https://keybase.io/benflips"
+    - label: "Google Scholar"
+      icon: "ai ai-google-scholar-square"
+      url: "https://scholar.google.com.au/citations?user=Kk1JhPwAAAAJ&hl"
+    - label: "Linked In"
+      icon: "fab fa-linkedin"
+      url: "https://www.linkedin.com/in/ben-phillips-7031a7191/"
+      
+Brenton von Takach:
+  name   : "Brenton von Takach"
+  short_name: Brenton
+  name_title: Dr
+  avatar : "/assets/images/mugshots/brenton.png"
+  position: "Premier's EMC Fellow"
+  institution: Curtin University
+  email: brenton.vontakach@curtin.edu.au
+  home: "https://benflips.github.io/PBG/team/brenton/"
+  bio    : "Research Fellow studying population ecology and genomics at Curtin"
+  links:
+    - label: "Twitter"
+      icon: "fab fa-fw fa-twitter-square"
+      url: "https://twitter.com/certhionyx"
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/brentonvt"
+    - label: "Google Scholar"
+      icon: "ai ai-google-scholar-square"
+      url: "https://scholar.google.com.au/citations?user=TGG2L-QAAAAJ&hl"
+    - label: "ResearchGate"
+      icon: "fab fa-researchgate"
+      url: "https://www.researchgate.net/profile/Brenton-Von-Takach"
+    - label: "iNaturalist"
+      icon: "ai ai-inaturalist"
+      url: "https://www.inaturalist.org/people/6384971"
+    - label: "ORCiD"
+      icon: "ai ai-orcid"
+      url: "https://orcid.org/0000-0002-7999-3521"
+    - label: "Keybase"
+      icon: "fab fa-keybase"
+      url: "https://keybase.io/brentonvt"

--- a/_includes/author-profile-flat.html
+++ b/_includes/author-profile-flat.html
@@ -1,4 +1,5 @@
-{% assign author=person.author%}
+{% assign author = person.author | default: person.authors[0] | default: site.author %}
+{% assign author = site.data.authors[author] | default: author %}
 
 <div itemscope itemtype="https://schema.org/Person">
 

--- a/_includes/author-profile-flat.html
+++ b/_includes/author-profile-flat.html
@@ -1,26 +1,28 @@
+{% assign author=person.author%}
+
 <div itemscope itemtype="https://schema.org/Person">
 
-  {% if include.author.avatar %}
+  {% if author.avatar %}
     <div class="author__avatar">
-      {% if include.author.home %}
-        <a href="{{ include.author.home | relative_url }}">
-          <img src="{{ include.author.avatar | relative_url }}" alt="{{ include.author.name }}" itemprop="image">
+      {% if author.home %}
+        <a href="{{ author.home | relative_url }}">
+          <img src="{{ author.avatar | relative_url }}" alt="{{ author.name }}" itemprop="image">
         </a>
       {% else %}
-        <img src="{{ include.author.avatar | relative_url }}" alt="{{ include.author.name }}" itemprop="image">
+        <img src="{{ author.avatar | relative_url }}" alt="{{ author.name }}" itemprop="image">
       {% endif %}
     </div>
   {% endif %}
 
   <div class="author__content">
-    {% if include.author.home %}
-      <a href="{{ include.author.home | relative_url }}"><h3 class="author__name" itemprop="name">{{ include.author.name }}</h3></a>
+    {% if author.home %}
+      <a href="{{ author.home | relative_url }}"><h3 class="author__name" itemprop="name">{{ author.name }}</h3></a>
     {% else %}
-      <h3 class="author__name" itemprop="name">{{ include.author.name }}</h3>
+      <h3 class="author__name" itemprop="name">{{ author.name }}</h3>
     {% endif %}
-    {% if include.author.bio %}
+    {% if author.bio %}
       <div class="author__bio" itemprop="description">
-        {{ include.author.bio | markdownify }}
+        {{ author.bio | markdownify }}
       </div>
     {% endif %}
   </div>
@@ -28,14 +30,14 @@
   <div class="author__urls-wrapper">
     <button class="btn btn--inverse">{{ site.data.ui-text[site.locale].follow_label | remove: ":" | default: "Follow" }}</button>
     <ul class="author__urls social-icons">
-      {% if include.author.location %}
+      {% if author.location %}
         <li itemprop="homeLocation" itemscope itemtype="https://schema.org/Place">
-          <i class="fas fa-fw fa-map-marker-alt" aria-hidden="true"></i> <span itemprop="name">{{ include.author.location }}</span>
+          <i class="fas fa-fw fa-map-marker-alt" aria-hidden="true"></i> <span itemprop="name">{{ author.location }}</span>
         </li>
       {% endif %}
 
-      {% if include.author.links %}
-        {% for link in include.author.links %}
+      {% if author.links %}
+        {% for link in author.links %}
           {% if link.label and link.url %}
             <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i><span class="label">{{ link.label }}</span></a></li>
           {% endif %}
@@ -43,10 +45,10 @@
       {% endif %}
 
 
-      {% if include.author.email %}
+      {% if author.email %}
         <li>
-          <a href="mailto:{{ include.author.email }}">
-            <meta itemprop="email" content="{{ include.author.email }}" />
+          <a href="mailto:{{ author.email }}">
+            <meta itemprop="email" content="{{ author.email }}" />
             <i class="fas fa-fw fa-envelope-square" aria-hidden="true"></i><span class="label">{{ site.data.ui-text[site.locale].email_label | default: "Email" }}</span>
           </a>
         </li>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,5 @@
+<!-- start custom head snippets -->
+
+<!-- insert favicons. use https://realfavicongenerator.net/ -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
+<!-- end custom head snippets -->

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -9,7 +9,7 @@ toc: true
 
 {% for person in site.staff %}
   {% include author-profile-flat.html %}
-  <br/><br/>
+  <br/>
 {% endfor %}
 
 ## Students

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -9,7 +9,7 @@ toc: true
 ## Staff
 
 {% for person in site.staff %}
-  {% include author-profile-flat.html author=person.author %}
+  {% include author-profile-flat.html %}
 {% endfor %}
 
 ## Students

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -4,12 +4,12 @@ title: "Team"
 author_profile: false
 toc: true
 ---
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons@1/css/academicons.min.css">
 
 ## Staff
 
 {% for person in site.staff %}
   {% include author-profile-flat.html %}
+
 {% endfor %}
 
 ## Students

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -9,7 +9,7 @@ toc: true
 
 {% for person in site.staff %}
   {% include author-profile-flat.html %}
-
+  <br/><br/>
 {% endfor %}
 
 ## Students

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -3,6 +3,7 @@ permalink: /team/
 title: "Team"
 author_profile: false
 toc: true
+toc_sticky: true
 ---
 
 ## Staff

--- a/_staff/ben.md
+++ b/_staff/ben.md
@@ -3,35 +3,7 @@ layout: single
 title:
 permalink: /team/ben/
 author_profile: true
-author:
-  name   : "Ben Phillips"
-  short_name: Ben
-  name_title: Prof.
-  avatar : "/assets/images/mugshots/ben.png"
-  position: "Premier's Science Fellow"
-  institution: Curtin University
-  email: ben.l.phillips@curtin.edu.au
-  home: "https://benflips.github.io/PBG/team/ben/"
-  bio    : "Professor of population biology at Curtin"
-  links:
-    - label: "Website"
-      icon: "fas fa-fw fa-link"
-      url: "https://benflips.github.io/PBG"
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      url: "https://twitter.com/benflips"
-    - label: "GitHub"
-      icon: "fab fa-fw fa-github"
-      url: "https://github.com/benflips"
-    - label: "Keybase"
-      icon: "fab fa-keybase"
-      url: "https://keybase.io/benflips"
-    - label: "Google Scholar"
-      icon: "ai ai-google-scholar-square"
-      url: "https://scholar.google.com.au/citations?user=Kk1JhPwAAAAJ&hl"
-    - label: "Linked In"
-      icon: "fab fa-linkedin"
-      url: "https://www.linkedin.com/in/ben-phillips-7031a7191/"
+author: Ben Phillips
 ---
 
 Ben is a Professor at Curtin University's School of Molecular and Life Sciences. He is a population biologist with a background in ecology and evolution, and is particularly interested in how spatial processes influence population and evolutionary dynamics. Ben started his professional life as a field biologist, but has slowly morphed into a modeler. He is interested in developing models describing population and evolutionary dynamics, and applying these to real problems in agriculture, health, and environment.

--- a/_staff/brenton.md
+++ b/_staff/brenton.md
@@ -3,38 +3,7 @@ layout: single
 title:
 permalink: /team/brenton/
 author_profile: true
-author:
-  name   : "Brenton von Takach"
-  short_name: Brenton
-  name_title: Dr
-  avatar : "/assets/images/mugshots/brenton.png"
-  position: "Premier's EMC Fellow"
-  institution: Curtin University
-  email: brenton.vontakach@curtin.edu.au
-  home: "https://benflips.github.io/PBG/team/brenton/"
-  bio    : "Research Fellow studying population ecology and genomics at Curtin"
-  links:
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      url: "https://twitter.com/certhionyx"
-    - label: "GitHub"
-      icon: "fab fa-fw fa-github"
-      url: "https://github.com/brentonvt"
-    - label: "Google Scholar"
-      icon: "ai ai-google-scholar-square"
-      url: "https://scholar.google.com.au/citations?user=TGG2L-QAAAAJ&hl"
-    - label: "ResearchGate"
-      icon: "fab fa-researchgate"
-      url: "https://www.researchgate.net/profile/Brenton-Von-Takach"
-    - label: "iNaturalist"
-      icon: "ai ai-inaturalist"
-      url: "https://www.inaturalist.org/people/6384971"
-    - label: "ORCiD"
-      icon: "ai ai-orcid"
-      url: "https://orcid.org/0000-0002-7999-3521"
-    - label: "Keybase"
-      icon: "fab fa-keybase"
-      url: "https://keybase.io/brentonvt"
+author: Brenton von Takach
 ---
 
 Brenton is a Research Fellow in the School of Molecular and Life Sciences at Curtin University in Perth. Broadly, he uses environmental, spatial, and genomic data to improve conservation management of threatened species and ecosystems. His publications focus on the topics of conservation ecology, population genomics, threatened species management, population demographics, landscape ecology and urban ecology. Brenton is a former Forrest Prospect Fellow at Curtin, focussing on the environmental, geographic and genomic processes involved in the decline of mammal species in Australia. Prior to this, Brenton worked at Charles Darwin University, helping to disentangle the drivers of vertebrate extinction in tropical savanna ecosystems. He completed his PhD in 2019 at The Australian National University in Canberra, which explored the genomic and demographic impacts of wildfire and logging on forest trees in southern Australia.


### PR DESCRIPTION
- Created an authors data file and called this in the teams collection.  This sets us up for site-wide author assignation and ensures a single canonical place for each author's data.
- Moved stylesheet link for academicons to its correct place (sitewide access again)
- Made minor improvements to team page

