### PR TITLE
Add Google Analytics (GA4) via minimal-mistakes analytics provider

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -172,3 +172,9 @@ category_archive:
 tag_archive:
   type: liquid
   path: /tags/
+
+analytics:
+  provider: "google-gtag"
+  google:
+    tracking_id: "G-MB47TJNY5W"
+    anonymize_ip: false


### PR DESCRIPTION
Enables page view tracking using the new GA4 property.